### PR TITLE
Add Homey v3 Energy support

### DIFF
--- a/app.json
+++ b/app.json
@@ -58,7 +58,8 @@
             "class": "sensor",
             "capabilities": [
                 "measure_power",
-                "meter_power",
+                "measure_power.consumed",
+                "meter_power.consumed",
                 "measure_power.generated",
                 "meter_power.generated",
                 "meter_gas.measure",
@@ -69,6 +70,12 @@
             },
             "capabilitiesOptions": {
                 "measure_power": {
+                    "title": {
+                        "nl": "Elektriciteit huidig verbruik/teruglevering",
+                        "en": "Electricity current usage/generated"
+                    }
+                },
+                "measure_power.consumed": {
                     "title": {
                         "nl": "Elektriciteit huidig verbruik",
                         "en": "Electricity current usage"
@@ -126,10 +133,35 @@
     "flow": {
         "triggers": [
             {
+                "id": "measure_power.changed",
+                "title": {
+                    "en": "Current total consumed/generated electricity changed",
+                    "nl": "Huidige totaal verbruikte/opgewekte elektriciteit gewijzigd"
+                },
+                "args": [
+                    {
+                        "name": "p1-smartmeter",
+                        "type": "device",
+                        "filter": "driver_id=p1-smartmeter"
+                    }
+                ],
+                "tokens": [
+                    {
+                        "name": "measure_power",
+                        "type": "number",
+                        "title": {
+                            "en": "Current total consumed/generated electricity (W)",
+                            "nl": "Huidige toaal verbruikte/opgewekte elektriciteit (W)"
+                        },
+                        "example": 500
+                    }
+                ]
+            },
+            {
                 "id": "measure_power.consumed.changed",
                 "title": {
                     "en": "Current electricity changed",
-                    "nl": "Huidige elektriciteitverbruik gewijzigd"
+                    "nl": "Huidige elektriciteitsverbruik gewijzigd"
                 },
                 "args": [
                     {
@@ -144,7 +176,7 @@
                         "type": "number",
                         "title": {
                             "en": "Current electricity (W)",
-                            "nl": "Huidige elektriciteitverbruik (W)"
+                            "nl": "Huidige elektriciteitsverbruik (W)"
                         },
                         "example": 500
                     }

--- a/app.json
+++ b/app.json
@@ -73,7 +73,8 @@
                     "title": {
                         "nl": "Elektriciteit huidig verbruik/teruglevering",
                         "en": "Electricity current usage/generated"
-                    }
+                    },
+                    "uiComponent": null
                 },
                 "measure_power.consumed": {
                     "title": {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "id": "com.p1",
-    "version": "2.0.4",
-    "compatibility": ">=2.0.0",
+    "version": "3.0.0",
+    "compatibility": ">=3.0.0",
     "brandColor": "#3399cc",
     "homeyCommunityTopicId": 6150,
     "sdk": 2,
@@ -57,15 +57,18 @@
             },
             "class": "sensor",
             "capabilities": [
-                "measure_power.consumed",
-                "meter_power.consumed",
+                "measure_power",
+                "meter_power",
                 "measure_power.generated",
                 "meter_power.generated",
                 "meter_gas.measure",
                 "meter_gas.consumed"
             ],
+            "energy": {
+                "cumulative": true
+            },
             "capabilitiesOptions": {
-                "measure_power.consumed": {
+                "measure_power": {
                     "title": {
                         "nl": "Elektriciteit huidig verbruik",
                         "en": "Electricity current usage"

--- a/drivers/p1-smartmeter/device.js
+++ b/drivers/p1-smartmeter/device.js
@@ -60,11 +60,19 @@ class P1Device extends Homey.Device {
         console.log("Data pushed:");
         console.log(data);
 
-        device.updateCapabilityValue('meter_gas.consumed', device.round(data.gas.reading));
-        device.updateCapabilityValue('measure_power', device.round(data.electricity.received.actual.reading * 1000));
-        device.updateCapabilityValue('measure_power.generated', device.round(data.electricity.delivered.actual.reading * 1000));
-        device.updateCapabilityValue('meter_power', device.round(data.electricity.received.tariff1.reading + data.electricity.received.tariff2.reading));
-        device.updateCapabilityValue('meter_power.generated', device.round(data.electricity.delivered.tariff1.reading + data.electricity.delivered.tariff2.reading));
+        let measurePowerConsumed = device.round(data.electricity.received.actual.reading * 1000),
+            measurePowerGenerated = device.round(data.electricity.delivered.actual.reading * 1000),
+            measurePower = measurePowerConsumed - measurePowerGenerated,
+            meterGasConsumed = device.round(data.gas.reading),
+            meterPowerConsumed = device.round(data.electricity.received.tariff1.reading + data.electricity.received.tariff2.reading),
+            meterPowerGenerated = device.round(data.electricity.delivered.tariff1.reading + data.electricity.delivered.tariff2.reading);
+
+        device.updateCapabilityValue('measure_power', measurePower);
+        device.updateCapabilityValue('meter_gas.consumed', meterGasConsumed);
+        device.updateCapabilityValue('measure_power.consumed', measurePowerConsumed);
+        device.updateCapabilityValue('measure_power.generated', measurePowerGenerated);
+        device.updateCapabilityValue('meter_power.consumed', meterPowerConsumed);
+        device.updateCapabilityValue('meter_power.generated', meterPowerGenerated);
     }
 
     updateCapabilityValue(capability, value) {
@@ -80,9 +88,14 @@ class P1Device extends Homey.Device {
                         "measure_power": value
                     });
                     break;
-                case 'meter_power':
+                case 'measure_power.consumed':
+                    device._driver.triggerMeasurePowerConsumedChangedFlow(device, {
+                        "measure_power.consumed": value
+                    });
+                    break;
+                case 'meter_power.consumed':
                     device._driver.triggerMeterPowerConsumedChangedFlow(device, {
-                        "meter_power": value
+                        "meter_power.consumed": value
                     });
                     break;
                 case 'measure_power.generated':

--- a/drivers/p1-smartmeter/device.js
+++ b/drivers/p1-smartmeter/device.js
@@ -61,9 +61,9 @@ class P1Device extends Homey.Device {
         console.log(data);
 
         device.updateCapabilityValue('meter_gas.consumed', device.round(data.gas.reading));
-        device.updateCapabilityValue('measure_power.consumed', device.round(data.electricity.received.actual.reading * 1000));
+        device.updateCapabilityValue('measure_power', device.round(data.electricity.received.actual.reading * 1000));
         device.updateCapabilityValue('measure_power.generated', device.round(data.electricity.delivered.actual.reading * 1000));
-        device.updateCapabilityValue('meter_power.consumed', device.round(data.electricity.received.tariff1.reading + data.electricity.received.tariff2.reading));
+        device.updateCapabilityValue('meter_power', device.round(data.electricity.received.tariff1.reading + data.electricity.received.tariff2.reading));
         device.updateCapabilityValue('meter_power.generated', device.round(data.electricity.delivered.tariff1.reading + data.electricity.delivered.tariff2.reading));
     }
 
@@ -75,14 +75,14 @@ class P1Device extends Homey.Device {
 
         if (value !== currentValue) {
             switch (capability) {
-                case 'measure_power.consumed':
+                case 'measure_power':
                     device._driver.triggerMeasurePowerConsumedChangedFlow(device, {
-                        "measure_power.consumed": value
+                        "measure_power": value
                     });
                     break;
-                case 'meter_power.consumed':
+                case 'meter_power':
                     device._driver.triggerMeterPowerConsumedChangedFlow(device, {
-                        "meter_power.consumed": value
+                        "meter_power": value
                     });
                     break;
                 case 'measure_power.generated':


### PR DESCRIPTION
# Homey v3 Energy support
An energy dashboard was added to the Homey app in v3, see [https://blog.athom.com/developers-homey-energy/](https://blog.athom.com/developers-homey-energy/).

The new energy feature requires cumulative energy meters, like the P1 meter, to add the following energy setting:
```json
"energy": {
    "cumulative": true
},
```

However this only works if the cumulative energy meter has the `measure_power` capability. And because the device currently only has custom capabilities named `measure_power.consumed` and `measure_power.generated` this did not work out of the box.

The `measure_power` capability has been added as a sum of the consumed/generated power and has been hidden from the device's sensor overview because I wouldn't find it useful if both consumed and generated are already displayed.

**Note** this PR bumps the version of the app from v2 to v3 because its a breaking change and compatibility has also been changed to a minimum Homey version of 3.0.0.


## Additional improvements
Maybe the two separate capabilities for measuring generated and consumed power can be removed so we're just left with the `measure_power` capability. Because it seems that Homey finally has proper support for negative values of power consumption (meaning energy is generated).

This is for example how the app for the Youless power meter works.
