### PR TITLE
feat: add source URL to app.json

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -21,6 +21,7 @@
     "name": "Leendert de Kok",
     "email": "koktaildotcom@hotmail.com"
   },
+  "source": "https://github.com/koktaildotcom/com.p1.smartmeter",
   "contributing": {
     "donate": {
       "paypal": {


### PR DESCRIPTION
It helps fellow Homey developers to quickly see the source code for
specific Homey apps. Because this app is public by itself, adding a
reference make finding the code a lot easier.